### PR TITLE
Fix npm scripts paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "main": "index.js",
   "start": "index.js",
   "scripts": {
-    "start": "node src/index.js",
-    "dev": "nodemon src/index.js"
+    "start": "node index.js",
+    "dev": "nodemon index.js"
   },
   "dependencies": {
     "@adminjs/express": "^6.1.1",


### PR DESCRIPTION
## Summary
- use the correct `index.js` path in npm `start` and `dev` scripts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ec113e6ec8320b6faef82f6ff589c